### PR TITLE
 #76 - Add a comprehensive error management architecture

### DIFF
--- a/src/cli/commands/test/mod.rs
+++ b/src/cli/commands/test/mod.rs
@@ -64,9 +64,33 @@ pub struct TestArgs {
 	pub root: PathBuf,
 }
 
+#[derive(PartialEq)]
+pub enum TestStatus {
+	SUCCESS,
+	FAILURE,
+}
+
+impl Into<bool> for TestStatus {
+	fn into(self) -> bool {
+		match self {
+			TestStatus::SUCCESS => true,
+			TestStatus::FAILURE => false,
+		}
+	}
+}
+
 pub struct TestResult {
 	pub output: String,
-	pub success: bool,
+	pub success: TestStatus,
+}
+
+impl From<(String, TestStatus)> for TestResult {
+	fn from(from: (String, TestStatus)) -> Self {
+		Self {
+			output: from.0,
+			success: from.1,
+		}
+	}
 }
 
 fn list_test_entrypoints(compiled_path: &PathBuf) -> Result<Vec<String>, TestCommandError> {
@@ -156,7 +180,7 @@ pub(crate) fn test_single_entrypoint(
 	test_entrypoint: String,
 	hint_processor: &BuiltinHintProcessor,
 	hooks: Option<Hooks>,
-) -> Result<(String, bool), TestCommandError> {
+) -> Result<TestResult, TestCommandError> {
 	let start = Instant::now();
 	let mut output = String::new();
 	let execution_uuid = Uuid::new_v4();
@@ -174,13 +198,13 @@ pub(crate) fn test_single_entrypoint(
 				test_entrypoint,
 				duration
 			));
-			(Some(res), true)
+			(Some(res), TestStatus::SUCCESS)
 		},
 		Err(CairoRunError::VirtualMachine(VirtualMachineError::CustomHint(
 			custom_error_message,
 		))) if custom_error_message == "skip" => {
 			output.push_str(&format!("[{}] {}\n", "SKIPPED".yellow(), test_entrypoint,));
-			(None, true)
+			(None, TestStatus::SUCCESS)
 		},
 		Err(CairoRunError::VirtualMachine(VirtualMachineError::CustomHint(
 			custom_error_message,
@@ -190,7 +214,7 @@ pub(crate) fn test_single_entrypoint(
 				"FAILED".red(),
 				test_entrypoint,
 			));
-			(None, false)
+			(None, TestStatus::FAILURE)
 		},
 		Err(e) => Err(TestCommandError::CairoRunError(e))?,
 	};
@@ -198,7 +222,7 @@ pub(crate) fn test_single_entrypoint(
 	purge_hint_buffer(&execution_uuid, &mut output);
 	let (mut runner, mut vm) = match opt_runner_and_output {
 		Some(runner_and_vm) => runner_and_vm,
-		None => return Ok((output, test_success)),
+		None => return Ok((output, test_success).into()),
 	};
 
 	// Display the execution output if present
@@ -215,7 +239,7 @@ pub(crate) fn test_single_entrypoint(
 	};
 
 	output.push('\n');
-	Ok((output, test_success))
+	Ok((output, test_success).into())
 }
 
 fn run_tests_for_one_file(
@@ -227,7 +251,8 @@ fn run_tests_for_one_file(
 ) -> Result<TestResult, TestCommandError> {
 	let program_json = deserialize_program_json(&path_to_compiled)?;
 
-	let (tests_output, tests_success) = test_entrypoints
+	let output = format!("Running tests in file {}\n", path_to_original.display());
+	let res = test_entrypoints
 		.into_iter()
 		.map(|test_entrypoint| {
 			test_single_entrypoint(
@@ -239,20 +264,17 @@ fn run_tests_for_one_file(
 		})
 		.collect::<Result<Vec<_>, TestCommandError>>()?
 		.into_iter()
-		.fold((String::new(), true), |mut a, b| {
-			a.0.push_str(&b.0);
-			a.1 &= b.1;
+		.fold((output, TestStatus::SUCCESS), |mut a, b| {
+			a.0.push_str(&b.output);
+			// SUCCESS if both a.1 and b.success are SUCCESS, otherwise, FAILURE
+			a.1 = if a.1 == TestStatus::SUCCESS && b.success == TestStatus::SUCCESS {
+				TestStatus::SUCCESS
+			} else {
+				TestStatus::FAILURE
+			};
 			a
 		});
-
-	Ok(TestResult {
-		output: format!(
-			"Running tests in file {}\n{}",
-			path_to_original.display(),
-			tests_output
-		),
-		success: tests_success,
-	})
+	Ok(res.into())
 }
 
 impl CommandExecution<TestOutput, TestCommandError> for TestArgs {

--- a/src/cli/commands/test/tests.rs
+++ b/src/cli/commands/test/tests.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use super::{
 	compile_and_list_entrypoints, setup_hint_processor, test_single_entrypoint, TestCommandError,
+	TestResult,
 };
 
 use crate::cli::commands::test::cache::cache::{read_cache_file, Cache, CacheError};
@@ -12,7 +13,7 @@ use crate::cli::commands::test::cache::cache::{read_cache_file, Cache, CacheErro
 pub fn run_single_test(
 	test_name: &str,
 	test_path: &PathBuf,
-) -> Result<(String, bool), TestCommandError> {
+) -> Result<TestResult, TestCommandError> {
 	let (_, path_to_compiled, _) = compile_and_list_entrypoints(test_path.to_owned())?;
 
 	let program_json = deserialize_program_json(&path_to_compiled)?;

--- a/src/hints/expect_revert/tests.rs
+++ b/src/hints/expect_revert/tests.rs
@@ -9,7 +9,10 @@ fn test_expect_revert(
 	#[case] expected_success: bool,
 ) -> Result<(), TestCommandError> {
 	let path = std::path::PathBuf::from(path);
-	let (_, actual_success) = run_single_test("test_expect_revert", &path).expect("Should be Ok");
-	assert_eq!(expected_success, actual_success);
+	let result: bool = run_single_test("test_expect_revert", &path)
+		.expect("Should be Ok")
+		.success
+		.into();
+	assert_eq!(expected_success, result);
 	Ok(())
 }


### PR DESCRIPTION
time spent: 0..5 days

a structure named ``TestResult``already existed, and was used only for general test result (if all test have passed or not)
I extended this to include every test result, and implemented some traits.
aliasing wasn't possible in an enum, so I just used SUCCESS and FAILURE.