### PR TITLE
Fix/cairo rs update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "cairo-rs"
 version = "0.1.0"
-source = "git+https://github.com/ptisserand/open-dust-cairo-rs?branch=cairo-foundry#87f37ce513cae484d6d94f0cc848e7cc9725941c"
+source = "git+https://github.com/open-dust/cairo-rs?branch=bug-state-cairo-foundry#cc4f7be0677f26ff6072b1431f17aa8169d4c9d0"
 dependencies = [
  "bincode",
  "clap",
@@ -739,7 +739,7 @@ checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/ptisserand/open-dust-cairo-rs?branch=cairo-foundry#87f37ce513cae484d6d94f0cc848e7cc9725941c"
+source = "git+https://github.com/open-dust/cairo-rs?branch=bug-state-cairo-foundry#cc4f7be0677f26ff6072b1431f17aa8169d4c9d0"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,7 +172,7 @@ dependencies = [
 [[package]]
 name = "cairo-rs"
 version = "0.1.0"
-source = "git+https://github.com/onlydustxyz/cairo-rs?branch=cairo-foundry#c066cfac5f1f484841dd3abf5cb48b1e93a04b0e"
+source = "git+https://github.com/ptisserand/open-dust-cairo-rs?branch=cairo-foundry#87f37ce513cae484d6d94f0cc848e7cc9725941c"
 dependencies = [
  "bincode",
  "clap",
@@ -175,6 +186,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "parse-hyperlinks",
+ "rand_core",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -555,15 +567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "html-escape"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15315cfa9503e9aa85a477138eff76a1b203a430703548052c330b69d8d8c205"
-dependencies = [
- "utf8-width",
-]
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,12 +739,9 @@ checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/onlydustxyz/cairo-rs?branch=cairo-foundry#c066cfac5f1f484841dd3abf5cb48b1e93a04b0e"
+source = "git+https://github.com/ptisserand/open-dust-cairo-rs?branch=cairo-foundry#87f37ce513cae484d6d94f0cc848e7cc9725941c"
 dependencies = [
- "html-escape",
  "nom",
- "percent-encoding",
- "thiserror",
 ]
 
 [[package]]
@@ -749,12 +749,6 @@ name = "paste"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
-
-[[package]]
-name = "percent-encoding"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
@@ -1099,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5ba05430fcd7c107ad9e4433bb3958722b13d97a44fd07a18dcf0eb6da667"
+checksum = "be7d6b2c959fde2a10dbc31d54bdd0307eecb7ef6c05c23a0263e65b57b3e18a"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -1111,21 +1105,45 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2 0.9.9",
+ "starknet-crypto-codegen",
+ "starknet-curve",
  "starknet-ff",
  "thiserror",
  "zeroize",
 ]
 
 [[package]]
-name = "starknet-ff"
+name = "starknet-crypto-codegen"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a80865f37a0dcd198f427356d939f1495144c26ed5123b1418ef33a63f82655"
+checksum = "6569d70430f0f6edc41f6820d00acf63356e6308046ca01e57eeac22ad258c47"
+dependencies = [
+ "starknet-curve",
+ "starknet-ff",
+ "syn",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84be6079d3060fdbd8b5335574fef3d3783fa2f7ee6474d08ae0c1e4b0a29ba4"
+dependencies = [
+ "starknet-ff",
+]
+
+[[package]]
+name = "starknet-ff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5874510620214ebeac50915b01d67437d8ca10a6682b1de85b93cd01157b58eb"
 dependencies = [
  "ark-ff",
+ "bigdecimal",
  "crypto-bigint",
  "getrandom",
  "hex",
+ "num-bigint",
  "serde",
  "thiserror",
 ]
@@ -1223,12 +1241,6 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "utf8-width"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version     = "0.1.0"
 
 [dependencies]
 assert_matches = "1.5.0"
-cairo-rs = { git = "https://github.com/ptisserand/open-dust-cairo-rs", branch = "cairo-foundry", features = [
+cairo-rs = { git = "https://github.com/open-dust/cairo-rs", branch = "bug-state-cairo-foundry", features = [
 	"hooks",
 ] }
 clap = { version = "3.2.6", features = ["derive"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version     = "0.1.0"
 
 [dependencies]
 assert_matches = "1.5.0"
-cairo-rs = { git = "https://github.com/onlydustxyz/cairo-rs", branch = "cairo-foundry", features = [
+cairo-rs = { git = "https://github.com/ptisserand/open-dust-cairo-rs", branch = "cairo-foundry", features = [
 	"hooks",
 ] }
 clap = { version = "3.2.6", features = ["derive"], default-features = false }

--- a/src/cli/commands/test/mod.rs
+++ b/src/cli/commands/test/mod.rs
@@ -298,15 +298,14 @@ pub(crate) fn test_single_entrypoint(
 
 	// Display the execution output if present
 	match runner.get_output(&mut vm) {
-		Ok(runner_output) => {
+		Ok(runner_output) =>
 			if !runner_output.is_empty() {
 				output.push_str(&format!(
 					"[{}]:\n{}",
 					"execution output".purple(),
 					&runner_output
 				));
-			}
-		},
+			},
 		Err(e) => eprintln!("failed to get output from the cairo runner: {e}"),
 	};
 
@@ -384,15 +383,14 @@ impl CommandExecution<TestOutput, TestCommandError> for TestArgs {
 			.map(compile_and_list_entrypoints)
 			.map(|res| -> Result<TestResult, TestCommandError> {
 				match res {
-					Ok((path_to_original, path_to_compiled, test_entrypoints)) => {
+					Ok((path_to_original, path_to_compiled, test_entrypoints)) =>
 						run_tests_for_one_file(
 							&mut hint_processor,
 							path_to_original,
 							path_to_compiled,
 							test_entrypoints,
 							hooks.clone(),
-						)
-					},
+						),
 					Err(err) => Err(err),
 				}
 			})

--- a/src/cli/commands/test/mod.rs
+++ b/src/cli/commands/test/mod.rs
@@ -18,10 +18,11 @@ use cairo_rs::{
 };
 use clap::{Args, ValueHint};
 use colored::Colorize;
-use rayon::prelude::*;
+// 2023-01-06: wwe can't execute parallel since HintFunc are reference counted
+// use rayon::prelude::*;
 use serde::Serialize;
 use serde_json::Value;
-use std::{fmt::Display, fs, io, path::PathBuf, sync::Arc, time::Instant};
+use std::{fmt::Display, fs, io, path::PathBuf, rc::Rc, sync::Arc, time::Instant};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -160,9 +161,9 @@ impl Display for TestOutput {
 }
 
 fn setup_hint_processor() -> BuiltinHintProcessor {
-	let skip_hint = HintFunc(Box::new(hints::skip));
-	let mock_call_hint = HintFunc(Box::new(hints::mock_call));
-	let expect_revert_hint = HintFunc(Box::new(expect_revert));
+	let skip_hint = Rc::new(HintFunc(Box::new(hints::skip)));
+	let mock_call_hint = Rc::new(HintFunc(Box::new(hints::mock_call)));
+	let expect_revert_hint = Rc::new(HintFunc(Box::new(expect_revert)));
 	let mut hint_processor = BuiltinHintProcessor::new_empty();
 	hint_processor.add_hint(String::from("skip()"), skip_hint);
 	hint_processor.add_hint(String::from("expect_revert()"), expect_revert_hint);
@@ -237,7 +238,7 @@ fn purge_hint_buffer(execution_uuid: &Uuid, output: &mut String) {
 /// ```ignore
 /// //assuming your program have a "test_function1" and "test_function2" functions.
 ///
-/// let hint_processor = setup_hint_processor();
+/// let mut hint_processor = setup_hint_processor();
 /// let plain_path = PathBuf::from("path_to_your_program");
 /// let compiled_path = compile(&plain_path)?;
 /// let program = deserialize_program_json(&compiled_path)?;
@@ -248,7 +249,7 @@ fn purge_hint_buffer(execution_uuid: &Uuid, output: &mut String) {
 pub(crate) fn test_single_entrypoint(
 	program: ProgramJson,
 	test_entrypoint: String,
-	hint_processor: &BuiltinHintProcessor,
+	hint_processor: &mut BuiltinHintProcessor,
 	hooks: Option<Hooks>,
 ) -> Result<TestResult, TestCommandError> {
 	let start = Instant::now();
@@ -256,7 +257,7 @@ pub(crate) fn test_single_entrypoint(
 	let execution_uuid = Uuid::new_v4();
 	init_buffer(execution_uuid);
 
-	let program = Program::from_json(program, &test_entrypoint)?;
+	let program = Program::from_json(program, Some(&test_entrypoint))?;
 
 	let res_cairo_run = cairo_run(program, hint_processor, execution_uuid, hooks);
 	let duration = start.elapsed();
@@ -297,14 +298,15 @@ pub(crate) fn test_single_entrypoint(
 
 	// Display the execution output if present
 	match runner.get_output(&mut vm) {
-		Ok(runner_output) =>
+		Ok(runner_output) => {
 			if !runner_output.is_empty() {
 				output.push_str(&format!(
 					"[{}]:\n{}",
 					"execution output".purple(),
 					&runner_output
 				));
-			},
+			}
+		},
 		Err(e) => eprintln!("failed to get output from the cairo runner: {e}"),
 	};
 
@@ -325,7 +327,7 @@ pub(crate) fn test_single_entrypoint(
 /// ```ignore
 /// //assuming your program have a "test_function1" and "test_function2" functions.
 ///
-/// let hint_processor = setup_hint_processor();
+/// let mut hint_processor = setup_hint_processor();
 /// let plain_path = PathBuf::from("path_to_your_program");
 /// let compiled_path = compile(&plain_path)?;
 /// let hooks = setup_hooks();
@@ -334,13 +336,15 @@ pub(crate) fn test_single_entrypoint(
 /// "test_fuction2"), hooks);
 /// ```
 fn run_tests_for_one_file(
-	hint_processor: &BuiltinHintProcessor,
+	hint_processor: &mut BuiltinHintProcessor,
 	path_to_original: PathBuf,
 	path_to_compiled: PathBuf,
 	test_entrypoints: Vec<String>,
 	hooks: Hooks,
 ) -> Result<TestResult, TestCommandError> {
-	let program_json = deserialize_program_json(&path_to_compiled)?;
+	let file = fs::File::open(&path_to_compiled).unwrap();
+	let reader = io::BufReader::new(file);
+	let program_json = deserialize_program_json(reader)?;
 
 	let output = format!("Running tests in file {}\n", path_to_original.display());
 	let res = test_entrypoints
@@ -371,22 +375,24 @@ fn run_tests_for_one_file(
 impl CommandExecution<TestOutput, TestCommandError> for TestArgs {
 	fn exec(&self) -> Result<TestOutput, TestCommandError> {
 		// Declare hints
-		let hint_processor = setup_hint_processor();
+		let mut hint_processor = setup_hint_processor();
 		let hooks = setup_hooks();
 
 		list_cairo_files(&self.root)?
-			.into_par_iter()
+			//.into_par_iter()
+			.into_iter()
 			.map(compile_and_list_entrypoints)
 			.map(|res| -> Result<TestResult, TestCommandError> {
 				match res {
-					Ok((path_to_original, path_to_compiled, test_entrypoints)) =>
+					Ok((path_to_original, path_to_compiled, test_entrypoints)) => {
 						run_tests_for_one_file(
-							&hint_processor,
+							&mut hint_processor,
 							path_to_original,
 							path_to_compiled,
 							test_entrypoints,
 							hooks.clone(),
-						),
+						)
+					},
 					Err(err) => Err(err),
 				}
 			})

--- a/src/cli/commands/test/tests.rs
+++ b/src/cli/commands/test/tests.rs
@@ -1,6 +1,8 @@
 use crate::cli::commands::{test::TestArgs, CommandExecution};
 use assert_matches::assert_matches;
 use cairo_rs::serde::deserialize_program::deserialize_program_json;
+use std::fs::File;
+use std::io::BufReader;
 use std::path::PathBuf;
 
 use super::{
@@ -15,13 +17,14 @@ pub fn run_single_test(
 	test_path: &PathBuf,
 ) -> Result<TestResult, TestCommandError> {
 	let (_, path_to_compiled, _) = compile_and_list_entrypoints(test_path.to_owned())?;
-
-	let program_json = deserialize_program_json(&path_to_compiled)?;
+	let file = File::open(&path_to_compiled).unwrap();
+	let reader = BufReader::new(file);
+	let program_json = deserialize_program_json(reader)?;
 
 	test_single_entrypoint(
 		program_json,
 		test_name.to_string(),
-		&setup_hint_processor(),
+		&mut setup_hint_processor(),
 		None,
 	)
 }

--- a/src/cli/commands/test/tests.rs
+++ b/src/cli/commands/test/tests.rs
@@ -1,9 +1,7 @@
 use crate::cli::commands::{test::TestArgs, CommandExecution};
 use assert_matches::assert_matches;
 use cairo_rs::serde::deserialize_program::deserialize_program_json;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::PathBuf;
+use std::{fs::File, io::BufReader, path::PathBuf};
 
 use super::{
 	compile_and_list_entrypoints, setup_hint_processor, test_single_entrypoint, TestCommandError,

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ops::Add;
 
 use cairo_rs::{
 	types::{exec_scope::ExecutionScopes, instruction::Opcode},
@@ -28,7 +29,8 @@ pub fn pre_step_instruction(
 ) -> Result<(), VirtualMachineError> {
 	let instruction = vm.decode_current_instruction()?;
 	if instruction.opcode == Opcode::Call {
-		let (operands, _operands_mem_addresses) = vm.compute_operands(&instruction)?;
+		let (operands, _operands_mem_addresses, _deduced_operands) =
+			vm.compute_operands(&instruction)?;
 
 		let new_pc = vm.compute_new_pc(&instruction, &operands)?;
 
@@ -43,7 +45,7 @@ pub fn pre_step_instruction(
 			let pc = vm.get_pc().clone();
 			let ap = vm.get_ap();
 			vm.insert_value(&ap, mocked_ret_value)?;
-			vm.set_pc(pc.add(2)?);
+			vm.set_pc(pc.add(2));
 			vm.set_ap(ap.offset + 1);
 			vm.skip_next_instruction_execution();
 		}

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-use std::ops::Add;
+use std::{collections::HashMap, ops::Add};
 
 use cairo_rs::{
 	types::{exec_scope::ExecutionScopes, instruction::Opcode},


### PR DESCRIPTION
Close #90 

This pull request update cairo-foundry code to match `cairo-foundry ` branch of `cairo-rs` based on [e3fc0aeb7a03f11a42d0f990ca0523f3988c02f4](https://github.com/lambdaclass/cairo-rs/commit/e3fc0aeb7a03f11a42d0f990ca0523f3988c02f4)

Due to use refereence counted for hint in cairo-rs, parallel execution of test have been disabled.

For CI purpose, I have modified Cargo.toml & Cargo.lock to use my own fork of cairo-rs.