### PR TITLE
Testcommand on error

### DIFF
--- a/src/cli/commands/test/mod.rs
+++ b/src/cli/commands/test/mod.rs
@@ -286,7 +286,15 @@ pub(crate) fn test_single_entrypoint(
 			));
 			(None, TestStatus::FAILURE)
 		},
-		Err(e) => Err(TestCommandError::CairoRunError(e))?,
+		Err(e) => {
+			output.push_str(&format!(
+				"[{}] {}\nError: {:?}\n\n",
+				"FAILED".red(),
+				test_entrypoint,
+				e
+			));
+			(None, TestStatus::FAILURE)
+		},
 	};
 
 	purge_hint_buffer(&execution_uuid, &mut output);


### PR DESCRIPTION
handle VM execution error other than skip or expect_revert and print it before next test execution  instead of panic!