### PR TITLE
feat: #98: retrieve function signatures from compiled cairo contract

### DIFF
--- a/src/cli/commands/test/tests.rs
+++ b/src/cli/commands/test/tests.rs
@@ -1,10 +1,10 @@
 use crate::cli::commands::{test::TestArgs, CommandExecution};
-use cairo_rs::serde::deserialize_program::deserialize_program_json;
+use cairo_rs::serde::deserialize_program::{deserialize_program, deserialize_program_json};
 use std::{fs::File, io::BufReader, path::PathBuf};
 
 use super::{
-	compile_and_list_entrypoints, setup_hint_processor, setup_hooks, test_single_entrypoint,
-	TestCommandError, TestResult,
+	compile, compile_and_list_entrypoints, retrieve_return_signatures, setup_hint_processor,
+	setup_hooks, test_single_entrypoint, TestCommandError, TestResult,
 };
 
 pub fn run_single_test(
@@ -34,4 +34,28 @@ fn test_cairo_contracts() {
 	}
 	.exec()
 	.unwrap();
+}
+
+#[test]
+fn get_function_return_signatures() {
+	let current_dir = std::env::current_dir().unwrap();
+	let root_dir = current_dir.join("test_cairo_contracts");
+
+	let contract_path = root_dir.join("test_retrieve_function_signatures.cairo");
+	let compiled_contract_path = compile(&contract_path).unwrap();
+	let file = File::open(&compiled_contract_path).unwrap();
+	let reader = BufReader::new(file);
+	let program = deserialize_program(reader, None).unwrap();
+	let signatures = retrieve_return_signatures(&program);
+
+	assert_eq!(signatures["__main__.array_sum"], ["felt"]);
+	assert_eq!(signatures["__main__.test_array_sum_negative"], [""; 0]);
+	assert_eq!(
+		signatures["__main__.get_account"],
+		[
+			"__main__.Account",
+			"starkware.cairo.common.uint256.Uint256",
+			"felt"
+		]
+	);
 }

--- a/src/io/test_files.rs
+++ b/src/io/test_files.rs
@@ -54,6 +54,7 @@ mod tests {
 		assert_eq!(
 			vec![
 				PathBuf::from("./test_cairo_contracts/test_invalid_program.cairo"),
+				PathBuf::from("./test_cairo_contracts/test_retrieve_function_signatures.cairo"),
 				PathBuf::from("./test_cairo_contracts/test_valid_program.cairo"),
 			],
 			result.unwrap()

--- a/test_cairo_contracts/test_retrieve_function_signatures.cairo
+++ b/test_cairo_contracts/test_retrieve_function_signatures.cairo
@@ -1,0 +1,109 @@
+%builtins output
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.serialize import serialize_word
+from starkware.cairo.common.uint256 import Uint256
+
+struct Account {
+    amount: Uint256,
+    id: felt,
+}
+// Computes the sum of the memory elements at addresses:
+//   arr + 0, arr + 1, ..., arr + (size - 1).
+func array_sum(arr: felt*, size) -> felt {
+    if (size == 0) {
+        return 0;
+    }
+
+    // size is not zero.
+    let sum_of_rest = array_sum(arr=arr + 1, size=size - 1);
+    return arr[0] + sum_of_rest;
+}
+
+func main{output_ptr: felt*}() {
+    const ARRAY_SIZE = 3;
+
+    // Allocate an array.
+    let (ptr) = alloc();
+
+    // Populate some values in the array.
+    assert [ptr] = 9;
+    assert [ptr + 1] = 16;
+    assert [ptr + 2] = 25;
+
+    // Call array_sum to compute the sum of the elements.
+    let sum = array_sum(arr=ptr, size=ARRAY_SIZE);
+
+    // Write the sum to the program output.
+    serialize_word(sum);
+
+    return ();
+}
+
+func test_array_sum_positive{output_ptr: felt*}() {
+    const ARRAY_SIZE = 3;
+
+    // Allocate an array.
+    let (ptr) = alloc();
+
+    // Populate some values in the array.
+    assert [ptr] = 9;
+    assert [ptr + 1] = 16;
+    assert [ptr + 2] = 25;
+
+    // Call array_sum to compute the sum of the elements.
+    let sum = array_sum(arr=ptr, size=ARRAY_SIZE);
+    assert sum = 50;
+    // Write the sum to the program output.
+    serialize_word(sum);
+
+    return ();
+}
+
+func test_array_sum_positive2{output_ptr: felt*}() {
+    const ARRAY_SIZE = 3;
+
+    // Allocate an array.
+    let (ptr) = alloc();
+
+    // Populate some values in the array.
+    assert [ptr] = 9;
+    assert [ptr + 1] = 16;
+    assert [ptr + 2] = 30;
+
+    // Call array_sum to compute the sum of the elements.
+    let sum = array_sum(arr=ptr, size=ARRAY_SIZE);
+    assert sum = 55;
+    // Write the sum to the program output.
+    serialize_word(sum);
+
+    return ();
+}
+
+func test_array_sum_negative{output_ptr: felt*}() {
+    const ARRAY_SIZE = 3;
+
+    // Allocate an array.
+    let (ptr) = alloc();
+
+    // Populate some values in the array.
+    assert [ptr] = 9;
+    assert [ptr + 1] = 16;
+    assert [ptr + 2] = 25;
+
+    // Call array_sum to compute the sum of the elements.
+    let sum = array_sum(arr=ptr, size=ARRAY_SIZE);
+    assert sum = 55;
+    // Write the sum to the program output.
+    serialize_word(sum);
+
+    return ();
+}
+
+func get_account(id: felt) -> (account: Account, total: Uint256, ref: felt) {
+    let amount = Uint256(low=1, high=0);
+    let account = Account(amount=amount, id=id);
+    let total = Uint256(low=1000, high=0);
+    let ref = id + 1;
+    return(account=account, total=total, ref=ref);
+}


### PR DESCRIPTION
# Retrieve function function signatures from compiled cairo contract

<!--- Please provide a general summary of your changes in the title above -->

This PR add `retrieve_return_signatures` function which return an `HashMap` with the following content:
- key: String: function symbol
- value: Vec<String>: list of types of function return signature

##  /!\ This feature depends on https://github.com/lambdaclass/cairo-rs/pull/773 /!\

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 2.5 days

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no API changes)
-   [ ] Build-related changes
-   [ ] Documentation content changes
-   [ ] Testing
-   [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #98 

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Cairo compiled function return signatures can be retrieved using `retrieve_return_signature`
- /!\ This feature depends on https://github.com/lambdaclass/cairo-rs/pull/773 /!\

# Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
