### PR TITLE
[Feature]: add a clean CLI command to remove all generated cache

### DIFF
--- a/src/cli/commands/clean/mod.rs
+++ b/src/cli/commands/clean/mod.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::{fmt::Display, fs, path::PathBuf};
 
 mod tests;
@@ -5,6 +6,7 @@ mod tests;
 use clap::Args;
 use serde::Serialize;
 
+use crate::compile::cache;
 use crate::compile::Error::CacheDirSupported;
 
 use thiserror::Error;
@@ -14,25 +16,39 @@ use super::CommandExecution;
 #[derive(Args, Debug)]
 pub struct CleanArgs {}
 
-#[derive(Debug, Serialize, Default)]
-pub struct CleanOutput(String);
+#[derive(Debug, Serialize)]
+pub struct CleanOutput {
+	/// The list of cleaned dirs
+	pub dirs: Vec<PathBuf>,
+}
 
 #[derive(Error, Debug)]
 pub enum CleanCommandError {
 	#[error(transparent)]
 	CleanCacheDirSupported(#[from] crate::compile::Error),
-	// TODO: add  the directory path and the error returned from remove_dir_all
-	#[error("Cannot remove directory")]
-	DirDeletion,
+	#[error("Cannot remove directory {dir}: {err}")]
+	DirDeletion { dir: PathBuf, err: io::Error },
 }
 
 impl Display for CleanOutput {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{}", &self.0)
+		if self.dirs.is_empty() {
+			write!(f, "No directory to clean")
+		} else {
+			write!(
+				f,
+				"Cleaned successfully: \n{}\n",
+				self.dirs
+					.iter()
+					.map(|path| path.display().to_string())
+					.collect::<Vec<_>>()
+					.join("\n")
+			)
+		}
 	}
 }
 
-fn clear_directory(path: &str) -> Result<(), CleanCommandError> {
+fn clean_cache_dir(path: &str) -> Result<Option<PathBuf>, CleanCommandError> {
 	let path_to_cache_dir = dirs::cache_dir().ok_or(CacheDirSupported)?;
 
 	let mut dir = PathBuf::new();
@@ -40,16 +56,32 @@ fn clear_directory(path: &str) -> Result<(), CleanCommandError> {
 	dir.push(path);
 
 	if dir.exists() {
-		fs::remove_dir_all(dir).map_err(|_err| CleanCommandError::DirDeletion)?;
+		fs::remove_dir_all(&dir).map_err(|err| CleanCommandError::DirDeletion {
+			// TODO: avoid .clone
+			dir: dir.clone(),
+			err,
+		})?;
+		return Ok(Some(dir));
 	}
 
-	Ok(())
+	Ok(None)
 }
 
 impl CommandExecution<CleanOutput, CleanCommandError> for CleanArgs {
 	fn exec(&self) -> Result<CleanOutput, CleanCommandError> {
-		clear_directory("cairo-foundry-cache")?;
-		clear_directory("compiled-cairo-files")?;
-		Ok(Default::default())
+		let mut cleaned_dirs: Vec<PathBuf> = Vec::new();
+
+		let cleaned_foundry_cache_dir = clean_cache_dir(cache::CAIRO_FOUNDRY_CACHE_DIR)?;
+		if cleaned_foundry_cache_dir.is_some() {
+			cleaned_dirs.push(cleaned_foundry_cache_dir.unwrap());
+		}
+		let cleaned_compiled_contract_dir =
+			clean_cache_dir(cache::CAIRO_FOUNDRY_COMPILED_CONTRACT_DIR)?;
+
+		if cleaned_compiled_contract_dir.is_some() {
+			cleaned_dirs.push(cleaned_compiled_contract_dir.unwrap());
+		}
+
+		Ok(CleanOutput { dirs: cleaned_dirs })
 	}
 }

--- a/src/cli/commands/clean/mod.rs
+++ b/src/cli/commands/clean/mod.rs
@@ -1,0 +1,55 @@
+use std::{fmt::Display, fs, path::PathBuf};
+
+mod tests;
+
+use clap::Args;
+use serde::Serialize;
+
+use crate::compile::Error::CacheDirSupported;
+
+use thiserror::Error;
+
+use super::CommandExecution;
+
+#[derive(Args, Debug)]
+pub struct CleanArgs {}
+
+#[derive(Debug, Serialize, Default)]
+pub struct CleanOutput(String);
+
+#[derive(Error, Debug)]
+pub enum CleanCommandError {
+	#[error(transparent)]
+	CleanCacheDirSupported(#[from] crate::compile::Error),
+	// TODO: add  the directory path and the error returned from remove_dir_all
+	#[error("Cannot remove directory")]
+	DirDeletion,
+}
+
+impl Display for CleanOutput {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}", &self.0)
+	}
+}
+
+fn clear_directory(path: &str) -> Result<(), CleanCommandError> {
+	let path_to_cache_dir = dirs::cache_dir().ok_or(CacheDirSupported)?;
+
+	let mut dir = PathBuf::new();
+	dir.push(&path_to_cache_dir);
+	dir.push(path);
+
+	if dir.exists() {
+		fs::remove_dir_all(dir).map_err(|_err| CleanCommandError::DirDeletion)?;
+	}
+
+	Ok(())
+}
+
+impl CommandExecution<CleanOutput, CleanCommandError> for CleanArgs {
+	fn exec(&self) -> Result<CleanOutput, CleanCommandError> {
+		clear_directory("cairo-foundry-cache")?;
+		clear_directory("compiled-cairo-files")?;
+		Ok(Default::default())
+	}
+}

--- a/src/cli/commands/clean/mod.rs
+++ b/src/cli/commands/clean/mod.rs
@@ -13,9 +13,8 @@ use crate::compile::cache;
 #[derive(Args, Debug)]
 pub struct CleanArgs {}
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 pub struct CleanOutput {
-	/// The list of cleaned dirs
 	pub dirs: Vec<(PathBuf, bool)>,
 }
 
@@ -46,7 +45,7 @@ fn remove_dir_all_if_exists(dir: &PathBuf) -> Result<bool, CleanCommandError> {
 			dir: dir.as_path().display().to_string(),
 			err,
 		})?;
-		return Ok(true);
+		return Ok(true)
 	}
 	Ok(false)
 }

--- a/src/cli/commands/clean/tests.rs
+++ b/src/cli/commands/clean/tests.rs
@@ -1,0 +1,7 @@
+use crate::cli::commands::{clean::CleanArgs, CommandExecution};
+
+#[test]
+fn should_clean_properly() {
+	let result = CleanArgs {}.exec();
+	assert!(result.is_ok(), "{}", result.unwrap_err())
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -74,15 +74,12 @@ impl fmt::Display for Output {
 impl CommandExecution<Output, CommandError> for Commands {
 	fn exec(&self) -> Result<Output, CommandError> {
 		match &self {
-			Commands::List(args) => {
-				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::List(o)))
-			},
-			Commands::Test(args) => {
-				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::Test(o)))
-			},
-			Commands::Clean(args) => {
-				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::Clean(o)))
-			},
+			Commands::List(args) =>
+				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::List(o))),
+			Commands::Test(args) =>
+				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::Test(o))),
+			Commands::Clean(args) =>
+				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::Clean(o))),
 		}
 	}
 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 mod list;
 // test module: contains everything related to the `Test` command
 pub mod test;
+// clean module: contains everything related to the `Clean` command
+mod clean;
 
 #[derive(Error, Debug)]
 // Todo: Think about a better way to bubble up the errors
@@ -17,6 +19,8 @@ pub enum CommandError {
 	ListCommandError(#[from] list::ListCommandError),
 	#[error(transparent)]
 	TestCommandError(#[from] test::TestCommandError),
+	#[error(transparent)]
+	CleanCommandError(#[from] clean::CleanCommandError),
 }
 
 /// Enum of all supported commands
@@ -26,6 +30,8 @@ pub enum Commands {
 	List(list::ListArgs),
 	// Test cairo programs
 	Test(test::TestArgs),
+	// Cleans the cache files
+	Clean(clean::CleanArgs),
 }
 
 /// Behaviour of a command
@@ -36,6 +42,7 @@ pub trait CommandExecution<F: Formattable, E: error::Error + Into<CommandError>>
 enum CommandOutputs {
 	List(list::ListOutput),
 	Test(test::TestOutput),
+	Clean(clean::CleanOutput),
 }
 
 /// The executed command output
@@ -49,6 +56,7 @@ impl Serialize for Output {
 		match &self.0 {
 			CommandOutputs::List(output) => output.serialize(serializer),
 			CommandOutputs::Test(output) => output.serialize(serializer),
+			CommandOutputs::Clean(output) => output.serialize(serializer),
 		}
 	}
 }
@@ -58,6 +66,7 @@ impl fmt::Display for Output {
 		match &self.0 {
 			CommandOutputs::List(output) => output.fmt(f),
 			CommandOutputs::Test(output) => output.fmt(f),
+			CommandOutputs::Clean(output) => output.fmt(f),
 		}
 	}
 }
@@ -65,10 +74,15 @@ impl fmt::Display for Output {
 impl CommandExecution<Output, CommandError> for Commands {
 	fn exec(&self) -> Result<Output, CommandError> {
 		match &self {
-			Commands::List(args) =>
-				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::List(o))),
-			Commands::Test(args) =>
-				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::Test(o))),
+			Commands::List(args) => {
+				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::List(o)))
+			},
+			Commands::Test(args) => {
+				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::Test(o)))
+			},
+			Commands::Clean(args) => {
+				args.exec().map_err(|e| e.into()).map(|o| Output(CommandOutputs::Clean(o)))
+			},
 		}
 	}
 }

--- a/src/compile/cache/mod.rs
+++ b/src/compile/cache/mod.rs
@@ -29,8 +29,8 @@ pub enum CacheError {
 	StripPrefixError(#[from] std::path::StripPrefixError),
 }
 
-const CAIRO_FOUNDRY_CACHE_DIR: &str = "cairo-foundry-cache";
-const CAIRO_FOUNDRY_COMPILED_CONTRACT_DIR: &str = "compiled-cairo-files";
+pub const CAIRO_FOUNDRY_CACHE_DIR: &str = "cairo-foundry-cache";
+pub const CAIRO_FOUNDRY_COMPILED_CONTRACT_DIR: &str = "compiled-cairo-files";
 
 fn read_cache_file(path: &PathBuf) -> Result<Cache, CacheError> {
 	let file = read_to_string(path)?;
@@ -45,7 +45,7 @@ fn is_valid_cairo_contract(contract_path: &PathBuf) -> Result<(), CacheError> {
 	if extension != "cairo" {
 		return Err(CacheError::InvalidContractExtension(
 			contract_path.to_owned(),
-		))
+		));
 	}
 	Ok(())
 }

--- a/src/compile/cache/mod.rs
+++ b/src/compile/cache/mod.rs
@@ -1,12 +1,11 @@
 #[cfg(test)]
 mod tests;
 
-use std::{fmt::Debug, fs::read_to_string, io, path::PathBuf};
-
-use thiserror::Error;
+use std::{env, fmt::Debug, fs::read_to_string, io, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use serde_json;
+use thiserror::Error;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Cache {
@@ -38,8 +37,14 @@ pub struct CacheDirNotSupportedError;
 pub const CAIRO_FOUNDRY_CACHE_DIR: &str = "cairo-foundry-cache";
 pub const CAIRO_FOUNDRY_COMPILED_CONTRACT_DIR: &str = "compiled-cairo-files";
 
+#[cfg(not(test))]
 pub fn cache_dir() -> Result<PathBuf, CacheDirNotSupportedError> {
 	dirs::cache_dir().ok_or(CacheDirNotSupportedError)
+}
+
+#[cfg(test)]
+pub fn cache_dir() -> Result<PathBuf, CacheDirNotSupportedError> {
+	Ok(env::temp_dir().join("cairo-foundry-tests"))
 }
 
 fn read_cache_file(path: &PathBuf) -> Result<Cache, CacheError> {

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -9,6 +9,8 @@ use std::{
 use thiserror::Error;
 use which::{which, Error as WhichError};
 
+pub mod cache;
+
 const JSON_FILE_EXTENTION: &str = "json";
 const CAIRO_COMPILE_BINARY: &str = "cairo-compile";
 
@@ -73,7 +75,7 @@ pub fn compile(path_to_cairo_file: &PathBuf) -> Result<PathBuf, Error> {
 					e
 				)
 			}),
-		))
+		));
 	}
 
 	// Retrieve only the file name to create a clean compiled file name.

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -75,7 +75,7 @@ pub fn compile(path_to_cairo_file: &PathBuf) -> Result<PathBuf, Error> {
 					e
 				)
 			}),
-		));
+		))
 	}
 
 	// Retrieve only the file name to create a clean compiled file name.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.5 day

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no API changes)
-   [ ] Build-related changes
-   [ ] Documentation content changes
-   [ ] Testing
-   [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: #78
 
This replaces: #68 

`cairo-foundry` caches stuff during its execution in order to avoid recompilation, those cached files are never deleted:

- files that contain hash of the cairo files [`CACHE_DIR/cairo-foundry-cache`](https://github.com/open-dust/cairo-foundry/blob/main/src/compile/cache/mod.rs#L32)
- the compiled contracts  [`CACHE_DIR/compiled-cairo-files`](https://github.com/open-dust/cairo-foundry/blob/main/src/compile/cache/mod.rs#L33)


# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The goal of this PR is to provide a `clean` CLI command that removes all the cache created by `cairo-foundy` in  the user's cache directory

### Usage example:

```bash
cairo-foundry clean
```

```bash
not found: /home/mohammedi/.cache/cairo-foundry-cache
not found: /home/mohammedi/.cache/compiled-cairo-files
Cache cleaned successfully.
```

I made sure to address all the questions/remarks of @tdelabro on the previous PR:
- Usage of globally available consts instead of hardcoded strings: https://github.com/open-dust/cairo-foundry/pull/78#discussion_r1047447146
- Usage of the new error management system: https://github.com/open-dust/cairo-foundry/pull/78#discussion_r1047447534
- Avoid mapping `Execute`: https://github.com/open-dust/cairo-foundry/pull/78#discussion_r1047447857

# Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
