### PR TITLE
Doc - Describe setup_hint_processor using Rustdoc comments (three slashes: ///)

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,7 @@
 # Configuration file for Rustfmt
 # https://rust-lang.github.io/rustfmt
 
-version = "Two"
+style_edition = "2021"
 
 # Basic
 hard_tabs = true

--- a/src/cli/commands/clean/mod.rs
+++ b/src/cli/commands/clean/mod.rs
@@ -48,7 +48,7 @@ fn remove_dir_all_if_exists(dir: &PathBuf) -> Result<bool, CleanCommandError> {
 			dir: dir.as_path().display().to_string(),
 			err,
 		})?;
-		return Ok(true)
+		return Ok(true);
 	}
 	Ok(false)
 }

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -66,7 +66,7 @@ pub fn compile(path_to_cairo_file: &PathBuf) -> Result<ProgramJson, Error> {
 			Ok(cache) =>
 				if cache.hash == hash {
 					let program_json: ProgramJson = serde_json::from_value(cache.program_json)?;
-					return Ok(program_json)
+					return Ok(program_json);
 				},
 			Err(err) => warn!(
 				"Error while reading cache {}: {err}",
@@ -112,6 +112,6 @@ pub fn compile_cairo_file(path_to_cairo_file: &PathBuf) -> Result<Vec<u8>, Error
 					e
 				)
 			}),
-		))
+		));
 	}
 }

--- a/src/hints/hint_processor/function_like_hint_processor/mod.rs
+++ b/src/hints/hint_processor/function_like_hint_processor/mod.rs
@@ -133,7 +133,7 @@ impl HintProcessor for FunctionLikeHintProcessor {
 				code: Code::RawCode(hint_code.to_string()),
 				ap_tracking: ap_tracking.clone(),
 				ids_data,
-			}))
+			}));
 		}
 		let name_func = trimmed_hint_code[..index_of_opening_parenthesis].to_string();
 		let list_args = trimmed_hint_code[index_of_opening_parenthesis + 1..]

--- a/src/hints/processor.rs
+++ b/src/hints/processor.rs
@@ -15,10 +15,10 @@ use crate::{
 ///
 /// The following custom hints are supported:
 /// - **skip**: Allows skipping certain instructions in the test execution.
-/// - **mock_call**: Simulates a call to another function or contract, enabling isolation
-///   of the unit being tested.
-/// - **expect_revert**: Asserts that a certain condition leads to a revert, allowing
-///   tests to confirm that the correct error handling is in place.
+/// - **mock_call**: Simulates a call to another function or contract, enabling isolation of the
+///   unit being tested.
+/// - **expect_revert**: Asserts that a certain condition leads to a revert, allowing tests to
+///   confirm that the correct error handling is in place.
 ///
 /// # Examples
 ///
@@ -30,7 +30,6 @@ use crate::{
 ///     let hint_processor = setup_hint_processor();
 /// # }
 /// ```
-///
 pub fn setup_hint_processor() -> FunctionLikeHintProcessor {
 	let skip_hint = Rc::new(HintFunc(Box::new(hints::skip)));
 	let mock_call_hint = Rc::new(HintFunc(Box::new(hints::mock_call)));

--- a/src/hints/processor.rs
+++ b/src/hints/processor.rs
@@ -5,7 +5,32 @@ use crate::{
 	hints::hint_processor::function_like_hint_processor::{FunctionLikeHintProcessor, HintFunc},
 };
 
-/// Create, setup and return a HintProcessor supporting our custom hints
+/// Create, setup, and return a `FunctionLikeHintProcessor` supporting our custom hints.
+///
+/// This function initializes a hint processor that is capable of handling custom hints
+/// such as skipping instructions, mocking calls, and expecting reverts during the execution
+/// of tests. The processor is designed to integrate seamlessly with the existing testing
+/// framework, allowing users to specify behaviors for their contracts without modifying
+/// the actual contract code.
+///
+/// The following custom hints are supported:
+/// - **skip**: Allows skipping certain instructions in the test execution.
+/// - **mock_call**: Simulates a call to another function or contract, enabling isolation
+///   of the unit being tested.
+/// - **expect_revert**: Asserts that a certain condition leads to a revert, allowing
+///   tests to confirm that the correct error handling is in place.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```no_run
+/// # use crate::hints::hint_processor::function_like_hint_processor::setup_hint_processor;
+/// # fn test() {
+///     let hint_processor = setup_hint_processor();
+/// # }
+/// ```
+///
 pub fn setup_hint_processor() -> FunctionLikeHintProcessor {
 	let skip_hint = Rc::new(HintFunc(Box::new(hints::skip)));
 	let mock_call_hint = Rc::new(HintFunc(Box::new(hints::mock_call)));


### PR DESCRIPTION
@tdelabro @Eikix 

Fixed #58 